### PR TITLE
Fix GAR interface to main module

### DIFF
--- a/gar.tf
+++ b/gar.tf
@@ -1,9 +1,11 @@
 # Google Artifact Registry
 module "gar" {
-  for_each   = var.enable_gar == true ? toset(["main"]) : []
-  depends_on = [module.service_accounts]
-  source     = "./modules/gar/"
-  project_id = var.project_id
-  location = var.location
-  description = var.description
+  for_each      = var.gar.enabled == true ? toset(["main"]) : []
+  depends_on    = [module.service_accounts]
+  source        = "./modules/gar/"
+  project_id    = var.project_id
+  location      = var.region
+  repository_id = var.gar.repository_id
+  description   = var.gar.description
+  format        = var.gar.format
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,14 @@ variable "enable_gcr" {
   default = false
 }
 
+variable "gar" {
+  type    = any
+  default = {
+    enabled = false
+    description = ""
+  }
+}
+
 variable "healthcare_fhir_stores" {
   type    = any
   default = {}


### PR DESCRIPTION
The GAR module was not bound to the main module variables

Usage

`locals {
  project_id = "..."
  region     = "us-east4"
  zone       = "us-east4-a"
  gar = {
    enabled       = true
    repository_id = "python-repo"
    description   = "Python PYPI repo"
    format        = "PYTHON"
  }
}`